### PR TITLE
Global auth; XML comments, and automatic 401 responses in Swagger

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -11,6 +11,16 @@
 	  <Visible>false</Visible> 
     </AdditionalFiles>
   </ItemGroup>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="$(OutputPath)$(AssemblyName).xml">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />

--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using API.Models.Errors;
 using API.Models.Errors.Auth;
 using Application.DTOs.Auth;
@@ -76,11 +76,9 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// </summary>
     /// <returns>The authenticated user's data and token.</returns>
     /// <response code="200">The user profile has been retrieved successfully.</response>
-    /// <response code="401">The user is not authenticated.</response>
     /// <response code="404">The authenticated user was not found.</response>
     [HttpGet("me")]
     [ProducesResponseType(typeof(AuthResponseDto), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse<AuthErrorCode>), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ErrorResponse<UserErrorCode>), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<AuthResponseDto>> Me()
     {

--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using API.Models.Errors;
 using API.Models.Errors.Auth;
 using Application.DTOs.Auth;
@@ -24,6 +24,7 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// <returns>The authenticated user's data and a JWT token.</returns>
     /// <response code="200">The user has been authenticated successfully.</response>
     /// <response code="400">The request payload is invalid.</response>
+    [AllowAnonymous]
     [HttpPost("login")]
     [ProducesResponseType(typeof(AuthResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse<LoginErrorCode>), StatusCodes.Status400BadRequest)]
@@ -50,6 +51,7 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// <response code="200">The user has been registered successfully.</response>
     /// <response code="400">The request payload is invalid.</response>
     /// <response code="409">The email address is already in use.</response>
+    [AllowAnonymous]
     [HttpPost("register")]
     [ProducesResponseType(typeof(AuthResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse<RegisterErrorCode>), StatusCodes.Status400BadRequest)]
@@ -76,7 +78,6 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// <response code="200">The user profile has been retrieved successfully.</response>
     /// <response code="401">The user is not authenticated.</response>
     /// <response code="404">The authenticated user was not found.</response>
-    [Authorize]
     [HttpGet("me")]
     [ProducesResponseType(typeof(AuthResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse<AuthErrorCode>), StatusCodes.Status401Unauthorized)]

--- a/API/Controllers/UsersController.cs
+++ b/API/Controllers/UsersController.cs
@@ -21,9 +21,9 @@ public class UsersController(IUserService userService) : ControllerBase
     /// <returns>The user data.</returns>
     /// <response code="200">The user was found.</response>
     /// <response code="404">The user was not found.</response>
+    [HttpGet("{id}")]
     [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse<UserErrorCode>), StatusCodes.Status404NotFound)]
-    [HttpGet("{id}")]
     public async Task<ActionResult<UserDto>> GetUserById(int id)
     {
         var user = await userService.GetByIdAsync(id);

--- a/API/Conventions/UnauthorizedProducesResponseConvention.cs
+++ b/API/Conventions/UnauthorizedProducesResponseConvention.cs
@@ -1,0 +1,41 @@
+﻿using API.Models.Errors;
+using API.Models.Errors.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace API.Conventions;
+
+/// <summary>
+/// Applies a <c>401 Unauthorized</c> Swagger response type to all controller actions
+/// that require authorization, unless they explicitly allow anonymous access or already define the response.
+/// </summary>
+/// <remarks>
+/// This convention ensures consistent documentation of authorization errors across protected endpoints
+/// by injecting a <see cref="ProducesResponseTypeAttribute"/> for <see cref="StatusCodes.Status401Unauthorized"/>.
+/// </remarks>
+public class UnauthorizedProducesResponseConvention : IApplicationModelConvention
+{
+    /// <inheritdoc/>
+    public void Apply(ApplicationModel application)
+    {
+        foreach (var controller in application.Controllers)
+        {
+            foreach (var action in controller.Actions)
+            {
+                var allowsAnonymous = controller.Attributes.OfType<AllowAnonymousAttribute>().Any()
+                                     || action.Attributes.OfType<AllowAnonymousAttribute>().Any();
+
+                var alreadyDeclared = action.Filters.OfType<ProducesResponseTypeAttribute>()
+                    .Any(attr => attr.StatusCode == StatusCodes.Status401Unauthorized);
+
+                if (!allowsAnonymous && !alreadyDeclared)
+                {
+                    action.Filters.Add(new ProducesResponseTypeAttribute(
+                        typeof(ErrorResponse<AuthErrorCode>),
+                        StatusCodes.Status401Unauthorized));
+                }
+            }
+        }
+    }
+}

--- a/API/Models/Errors/ErrorResponse.cs
+++ b/API/Models/Errors/ErrorResponse.cs
@@ -32,8 +32,14 @@ public class ErrorResponse
     /// </summary>
     public string Code { get; set; }
 
+#pragma warning disable IDE0079
+#pragma warning disable SA1623
+
     /// <summary>
-    /// Gets or sets the human-readable error message.
+    /// The human-readable error message.
     /// </summary>
     public string? Message { get; set; }
+
+#pragma warning restore SA1623
+#pragma warning restore IDE0079
 }

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
+using API.Conventions;
 using API.Middleware;
 using API.Models.Errors;
 using API.Models.Errors.Auth;
@@ -9,6 +11,7 @@ using Application.Services;
 using Domain.Interfaces;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -26,6 +29,10 @@ builder.Services.AddSwaggerGen(options =>
         Title = "Transport API",
         Version = "v1",
     });
+
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
 
     options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -69,7 +69,11 @@ builder.Services.AddScoped<IJWTTokenService, JWTTokenService>();
 builder.Services.AddScoped<IPasswordHasher, PasswordHasher>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 
-builder.Services.AddControllers()
+builder.Services
+    .AddControllers(options =>
+    {
+        options.Filters.Add(new AuthorizeFilter());
+    })
     .AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -73,6 +73,7 @@ builder.Services
     .AddControllers(options =>
     {
         options.Filters.Add(new AuthorizeFilter());
+        options.Conventions.Add(new UnauthorizedProducesResponseConvention());
     })
     .AddJsonOptions(options =>
     {


### PR DESCRIPTION
Closes #27 

---
Od teraz wszystkie endpointy wymagają zalogowania, chyba że sprecyzowano `[AllowAnonymous]` (czyli `Login` i `Register` na ten moment).

W Swaggerze generują się opisy endpointów (summary, response itp).

Dodano konwencję, która w przypadku wykrycia, że endpoint jest `[Authorize]`, doda `ProducesResponseType` z `401`. Nie doda jednak ona `<response code="401">`, ale jest to zbędne - na swaggerze wystarczy zwykłe *Unauthorized*.

Dopracowano kolejność atrybutów.

W `ErrorResponse` zmieniono komentarz `Message` na niezgodny ze StyleCop, ponieważ ten komentarz jest wyświetlany w Swaggerze. Ostrzeżenie wyłączono (SA1623). Ponieważ VS nie do końca ogarniał, że wyłączenie ostrzeżenia jest potrzebne, wyłączono sugestię jego usunięcia (IDE0079).