### PR TITLE
Enable perl grep

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -36,7 +36,7 @@ jobs:
         id: dotnet-build
         run: | 
           dotnet build --ucr -c Debug --no-restore -warnaserror:false -v:minimal > build.log
-          grep -E '(?!SA0001)(SA[0-9]{4}|CS[0-9]{4})' build.log > warnings.txt || true
+          grep -P '(?!SA0001)(SA[0-9]{4}|CS[0-9]{4})' build.log > warnings.txt || true
           echo "warnings<<EOF" >> $GITHUB_OUTPUT
           cat warnings.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Build-check jak się okazało nie interpretował wykorzystanej składni regex'a w poprawny sposób. Przez co sypał warningi i nie znajdował tego co miał znaleźć. Dzięki wsparciu @Rivixer udało się określić że rozwiązanie to określenie aby grep korzystał ze składni regex'a z języka perl