### PR TITLE
Fix duplicated warnings

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -36,7 +36,7 @@ jobs:
         id: dotnet-build
         run: | 
           dotnet build --ucr -c Debug --no-restore -warnaserror:false -v:minimal > build.log
-          grep -P '(?!SA0001)(SA[0-9]{4}|CS[0-9]{4})' build.log > warnings.txt || true
+          grep -P '(?!SA0001)(SA[0-9]{4}|CS[0-9]{4})' build.log | awk '!seen[$0] {print} {++seen[$0]}' > warnings.txt || true
           echo "warnings<<EOF" >> $GITHUB_OUTPUT
           cat warnings.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Czasami workflow build-check wypisuje wiele razy tą samą linijkę. Od teraz już nie