### PR TITLE
Refactor GTFS import to support bulk and EF Core strategies

### DIFF
--- a/API/appsettings.example.json
+++ b/API/appsettings.example.json
@@ -6,9 +6,9 @@
     }
   },
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "AppDbConnectionString": "server=localhost;database=Transport;User=admin;Password=1234;"
-  },
+    "ConnectionStrings": {
+      "AppDbConnectionString": "server=localhost;database=Transport;User=admin;Password=1234;AllowLoadLocalInfile=false"
+    },
   "Jwt": {
     "Key": "94cf436835b362ee1d0c8961d3c8e9deafa19a7ab801cacc7321d36685841ac5",
     "Issuer": "localhost",

--- a/PublicTransportService/Application/Interfaces/IGtfsImportService.cs
+++ b/PublicTransportService/Application/Interfaces/IGtfsImportService.cs
@@ -16,8 +16,8 @@ public interface IGtfsImportService
     /// </param>
     /// <param name="chunkSize">
     /// Optional size of data batches to be inserted into the database.
-    /// A higher value may speed up the process but consume more memory. Default is 10,000.
+    /// A higher value may speed up the process but consume more memory.
     /// </param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task ImportAsync(string? localZipPath = null, int chunkSize = 10_000);
+    Task ImportAsync(string? localZipPath, int chunkSize);
 }

--- a/PublicTransportService/Infrastructure/Importing/BulkGtfsImportStrategy.cs
+++ b/PublicTransportService/Infrastructure/Importing/BulkGtfsImportStrategy.cs
@@ -1,0 +1,76 @@
+﻿using System.Diagnostics;
+using EFCore.BulkExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PublicTransportService.Infrastructure.Data;
+
+namespace PublicTransportService.Infrastructure.Importing;
+
+/// <summary>
+/// Represents a strategy for importing GTFS data using bulk insert operations.
+/// </summary>
+internal sealed class BulkGtfsImportStrategy(PTSDbContext context, ILogger<BulkGtfsImportStrategy> logger)
+    : IGtfsImportStrategy
+{
+    /// <inheritdoc/>
+    public bool RequiresTransaction => false;
+
+    /// <inheritdoc/>
+    public async Task ImportAsync<TCsv, TEntity>(
+        string path,
+        Func<IAsyncEnumerable<TCsv>, IAsyncEnumerable<TEntity>> map,
+        int chunkSize)
+        where TCsv : class
+        where TEntity : class
+    {
+        var totalStopwatch = Stopwatch.StartNew();
+
+        var tableName = context.Model.FindEntityType(typeof(TEntity))?.GetTableName();
+        if (string.IsNullOrEmpty(tableName))
+        {
+            logger.LogWarning(
+                "Table name for {EntityLabel} not found in the model. Using default name.",
+                tableName = typeof(TEntity).Name);
+        }
+
+        var tmpTableName = $"{tableName}_tmp";
+        logger.LogInformation("Preparing temporary table {Table}", tmpTableName);
+        var dropSql = $"DROP TABLE IF EXISTS `{tmpTableName}`;";
+        var createSql = $"CREATE TABLE `{tmpTableName}` LIKE `{tableName}`;";
+        _ = await context.Database.ExecuteSqlRawAsync(dropSql);
+        _ = await context.Database.ExecuteSqlRawAsync(createSql);
+
+        var processed = 0;
+        logger.LogInformation("Preparing and inserting chunks into {Table}", tmpTableName);
+        var chunks = CsvChunkGenerator.GenerateChunksAsync(path, chunkSize, map);
+        await foreach (var chunk in chunks)
+        {
+            await context.BulkInsertAsync(chunk, new BulkConfig
+            {
+                CustomDestinationTableName = tmpTableName,
+                SetOutputIdentity = false,
+                EnableStreaming = true,
+                PreserveInsertOrder = false,
+                UseTempDB = false,
+            });
+
+            processed += chunk.Count;
+            Console.Write($"\rInserted {processed} records into {tmpTableName}".PadRight(80));
+        }
+
+        Console.Write('\r');
+        logger.LogInformation("Bulk inserted all {Count} records into {Table}", processed, tmpTableName);
+
+        var renameSql = $"RENAME TABLE `{tableName}` TO `{tableName}_old`, `{tmpTableName}` TO `{tableName}`;";
+        var dropOldSql = $"DROP TABLE `{tableName}_old`;";
+        _ = await context.Database.ExecuteSqlRawAsync(renameSql);
+        _ = await context.Database.ExecuteSqlRawAsync(dropOldSql);
+        logger.LogInformation("Swapped tables: {TmpTable} → {Table} and dropped old", tmpTableName, tableName);
+
+        totalStopwatch.Stop();
+        logger.LogInformation(
+            "Total bulk insert duration for {Table}: {Time:N2} seconds",
+            tableName,
+            totalStopwatch.Elapsed.TotalSeconds);
+    }
+}

--- a/PublicTransportService/Infrastructure/Importing/CsvChunkGenerator.cs
+++ b/PublicTransportService/Infrastructure/Importing/CsvChunkGenerator.cs
@@ -1,0 +1,51 @@
+﻿using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace PublicTransportService.Infrastructure.Importing;
+
+/// <summary>
+/// Provides a static helper for generating record chunks from a CSV file.
+/// </summary>
+public static class CsvChunkGenerator
+{
+    /// <summary>
+    /// Reads a CSV file and maps it to a sequence of entity chunks.
+    /// </summary>
+    /// <typeparam name="TCsv">The CSV record type.</typeparam>
+    /// <typeparam name="TEntity">The entity type.</typeparam>
+    /// <param name="path">The CSV file path.</param>
+    /// <param name="chunkSize">Number of items per chunk.</param>
+    /// <param name="map">Mapping function.</param>
+    /// <returns>An async enumerable of entity chunks.</returns>
+    public static async IAsyncEnumerable<List<TEntity>> GenerateChunksAsync<TCsv, TEntity>(
+        string path,
+        int chunkSize,
+        Func<IAsyncEnumerable<TCsv>, IAsyncEnumerable<TEntity>> map)
+        where TCsv : class
+        where TEntity : class
+    {
+        using var reader = new StreamReader(path);
+        using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HeaderValidated = null,
+            MissingFieldFound = null,
+        });
+
+        var batch = new List<TEntity>(chunkSize);
+        await foreach (var entity in map(csv.GetRecordsAsync<TCsv>()))
+        {
+            batch.Add(entity);
+            if (batch.Count >= chunkSize)
+            {
+                yield return batch;
+                batch = new List<TEntity>(chunkSize);
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            yield return batch;
+        }
+    }
+}

--- a/PublicTransportService/Infrastructure/Importing/EfCoreGtfsImportStrategy.cs
+++ b/PublicTransportService/Infrastructure/Importing/EfCoreGtfsImportStrategy.cs
@@ -1,0 +1,103 @@
+﻿using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PublicTransportService.Infrastructure.Data;
+
+namespace PublicTransportService.Infrastructure.Importing;
+
+/// <summary>
+/// Represents a strategy for importing GTFS chunks into the database using Entity Framework Core.
+/// </summary>
+internal sealed class EfCoreGtfsImportStrategy(PTSDbContext context, ILogger<EfCoreGtfsImportStrategy> logger)
+    : IGtfsImportStrategy
+{
+    /// <inheritdoc/>
+    public bool RequiresTransaction => true;
+
+    /// <inheritdoc/>
+    public async Task ImportAsync<TCsv, TEntity>(
+        string path,
+        Func<IAsyncEnumerable<TCsv>, IAsyncEnumerable<TEntity>> map,
+        int chunkSize)
+        where TCsv : class
+        where TEntity : class
+    {
+        var totalStopwatch = Stopwatch.StartNew();
+
+        var tableName = context.Model.FindEntityType(typeof(TEntity))?.GetTableName();
+        if (string.IsNullOrEmpty(tableName))
+        {
+            logger.LogWarning(
+                "Table name for {EntityLabel} not found in the model. Using default name.",
+                tableName = typeof(TEntity).Name);
+        }
+
+        logger.LogInformation("Clearing {Table}", tableName);
+
+        var sectionStopwatch = Stopwatch.StartNew();
+        _ = await context.Set<TEntity>().ExecuteDeleteAsync();
+        _ = await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        sectionStopwatch.Stop();
+
+        logger.LogInformation(
+            "Cleared {Table} in {Time:N2} seconds",
+            tableName,
+            sectionStopwatch.Elapsed.TotalSeconds);
+
+        logger.LogInformation("Generating chunks for {Table}", tableName);
+
+        sectionStopwatch = Stopwatch.StartNew();
+        var chunks = await CsvChunkGenerator.GenerateChunksAsync(path, chunkSize, map).ToListAsync();
+        var allRecords = chunks.Sum(c => c.Count);
+        var chunkTimes = new Queue<TimeSpan>();
+        sectionStopwatch.Stop();
+
+        logger.LogInformation(
+            "Generated {Count} chunks with {TotalRecords} records for {Table} in {Time:N2} seconds",
+            chunks.Count,
+            allRecords,
+            tableName,
+            sectionStopwatch.Elapsed.TotalSeconds);
+
+        const int ChunkHistoryLimit = 10;
+        var processed = 0;
+        foreach (var chunk in chunks)
+        {
+            var chunkStopwatch = Stopwatch.StartNew();
+
+            await context.AddRangeAsync(chunk);
+            _ = await context.SaveChangesAsync();
+            context.ChangeTracker.Clear();
+
+            chunkStopwatch.Stop();
+
+            if (chunkTimes.Count >= ChunkHistoryLimit)
+            {
+                _ = chunkTimes.Dequeue();
+            }
+
+            chunkTimes.Enqueue(chunkStopwatch.Elapsed);
+
+            processed += chunk.Count;
+
+            var avgMs = chunkTimes.Average(t => t.TotalMilliseconds);
+            var remainingRecords = allRecords - processed;
+            var remainingChunks = (int)Math.Ceiling((double)remainingRecords / chunkSize);
+            var eta = TimeSpan.FromMilliseconds(avgMs * remainingChunks);
+
+            Console.Write(
+                $"\rInserted {processed}/{allRecords} records to {tableName}..." +
+                $" ETA: {eta:hh\\:mm\\:ss}".PadRight(80));
+        }
+
+        Console.Write("\r");
+        totalStopwatch.Stop();
+
+        logger.LogInformation(
+            "Inserted all {Count} records into {Table} in {Time:N2} seconds",
+            processed,
+            tableName,
+            totalStopwatch.Elapsed.TotalSeconds);
+    }
+}

--- a/PublicTransportService/Infrastructure/Importing/IGtfsImportStrategy.cs
+++ b/PublicTransportService/Infrastructure/Importing/IGtfsImportStrategy.cs
@@ -1,0 +1,28 @@
+﻿namespace PublicTransportService.Infrastructure.Importing;
+
+/// <summary>
+/// Represents a strategy for importing GTFS entities into a specific destination table.
+/// </summary>
+internal interface IGtfsImportStrategy
+{
+    /// <summary>
+    /// Gets a value indicating whether the import operation requires a transaction.
+    /// </summary>
+    bool RequiresTransaction { get; }
+
+    /// <summary>
+    /// Imports the given GTFS entity data into the specified database table.
+    /// </summary>
+    /// <typeparam name="TCsv">The type representing a CSV row.</typeparam>
+    /// <typeparam name="TEntity">The target entity type.</typeparam>
+    /// <param name="path">The path to the GTFS CSV file.</param>
+    /// <param name="map">A function mapping a CSV record to an entity.</param>
+    /// <param name="chunkSize">The number of records to insert per batch.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task ImportAsync<TCsv, TEntity>(
+        string path,
+        Func<IAsyncEnumerable<TCsv>, IAsyncEnumerable<TEntity>> map,
+        int chunkSize)
+        where TCsv : class
+        where TEntity : class;
+}

--- a/PublicTransportService/Infrastructure/Mapping/GtfsCsvMapper.cs
+++ b/PublicTransportService/Infrastructure/Mapping/GtfsCsvMapper.cs
@@ -1,0 +1,141 @@
+﻿using System.Globalization;
+using PublicTransportService.Domain.Entities;
+using PublicTransportService.Domain.Enums;
+using PublicTransportService.Infrastructure.Models.GtfsCsv;
+
+namespace PublicTransportService.Infrastructure.Mapping;
+
+/// <summary>
+/// Provides asynchronous mapping functions to convert GTFS CSV records into domain entities.
+/// </summary>
+internal static class GtfsCsvMapper
+{
+    /// <summary>
+    /// Maps a stream of <see cref="StopCsv"/> records to <see cref="Stop"/> entities.
+    /// </summary>
+    /// <param name="csvs">An async enumerable of CSV records.</param>
+    /// <returns>Async enumerable of mapped <see cref="Stop"/> entities.</returns>
+    public static async IAsyncEnumerable<Stop> ParseStops(IAsyncEnumerable<StopCsv> csvs)
+    {
+        await foreach (var csv in csvs)
+        {
+            yield return new Stop
+            {
+                Id = csv.stop_id,
+                Name = csv.stop_name,
+                Code = csv.stop_code,
+                PlatformCode = csv.platform_code,
+                Latitude = double.Parse(csv.stop_lat, CultureInfo.InvariantCulture),
+                Longitude = double.Parse(csv.stop_lon, CultureInfo.InvariantCulture),
+                LocationType = (LocationType)int.Parse(csv.location_type),
+                ParentStation = csv.parent_station,
+                WheelchairBoarding = csv.wheelchair_boarding == "1",
+                NameStem = csv.stop_name_stem,
+                TownName = csv.town_name,
+                StreetName = csv.street_name,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Maps a stream of <see cref="RouteCsv"/> records to <see cref="Route"/> entities.
+    /// </summary>
+    /// <param name="csvs">An async enumerable of CSV records.</param>
+    /// <returns>Async enumerable of mapped <see cref="Route"/> entities.</returns>
+    public static async IAsyncEnumerable<Route> ParseRoutes(IAsyncEnumerable<RouteCsv> csvs)
+    {
+        await foreach (var csv in csvs)
+        {
+            yield return new Route
+            {
+                Id = csv.route_id,
+                AgencyId = csv.agency_id,
+                ShortName = csv.route_short_name,
+                LongName = csv.route_long_name,
+                Type = (RouteType)int.Parse(csv.route_type),
+                Color = csv.route_color,
+                TextColor = csv.route_text_color,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Maps a stream of <see cref="ShapeCsv"/> records to <see cref="Shape"/> entities.
+    /// </summary>
+    /// <param name="csvs">An async enumerable of CSV records.</param>
+    /// <returns>Async enumerable of mapped <see cref="Shape"/> entities.</returns>
+    public static async IAsyncEnumerable<Shape> ParseShapes(IAsyncEnumerable<ShapeCsv> csvs)
+    {
+        await foreach (var csv in csvs)
+        {
+            yield return new Shape
+            {
+                Id = csv.shape_id,
+                PtSequence = int.Parse(csv.shape_pt_sequence),
+                PtLatitude = double.Parse(csv.shape_pt_lat, CultureInfo.InvariantCulture),
+                PtLongitude = double.Parse(csv.shape_pt_lon, CultureInfo.InvariantCulture),
+            };
+        }
+    }
+
+    /// <summary>
+    /// Maps a stream of <see cref="TripCsv"/> records to <see cref="Trip"/> entities.
+    /// </summary>
+    /// <param name="csvs">An async enumerable of CSV records.</param>
+    /// <returns>Async enumerable of mapped <see cref="Trip"/> entities.</returns>
+    public static async IAsyncEnumerable<Trip> ParseTrips(IAsyncEnumerable<TripCsv> csvs)
+    {
+        await foreach (var csv in csvs)
+        {
+            yield return new Trip
+            {
+                Id = csv.trip_id,
+                RouteId = csv.route_id,
+                ServiceId = csv.service_id,
+                HeadSign = csv.trip_headsign,
+                ShortName = csv.trip_short_name,
+                ShapeId = csv.shape_id,
+                DirectionId = int.Parse(csv.direction_id),
+                WheelchairAccessible = csv.wheelchair_accessible == "1",
+                HiddenBlockId = csv.hidden_block_id,
+                Brigade = csv.brigade,
+                FleetType = csv.fleet_type,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Maps a stream of <see cref="StopTimeCsv"/> records to <see cref="StopTime"/> entities.
+    /// </summary>
+    /// <param name="csvs">An async enumerable of CSV records.</param>
+    /// <returns>Async enumerable of mapped <see cref="StopTime"/> entities with auto-incremented IDs.</returns>
+    public static async IAsyncEnumerable<StopTime> ParseStopTimes(IAsyncEnumerable<StopTimeCsv> csvs)
+    {
+        var currentId = 1;
+        await foreach (var csv in csvs)
+        {
+            yield return new StopTime
+            {
+                Id = currentId++,
+                TripId = csv.trip_id,
+                StopId = csv.stop_id,
+                StopSequence = int.Parse(csv.stop_sequence),
+                ArrivalTime = ParseTimeToSeconds(csv.arrival_time),
+                DepartureTime = ParseTimeToSeconds(csv.departure_time),
+                PickupType = (PickupType)int.Parse(csv.pickup_type),
+                DropOffType = (DropOffType)int.Parse(csv.drop_off_type),
+            };
+        }
+    }
+
+    private static int ParseTimeToSeconds(string time)
+    {
+        var parts = time.Split(':');
+        return parts.Length != 3
+            || !int.TryParse(parts[0], out var h)
+            || !int.TryParse(parts[1], out var m)
+            || !int.TryParse(parts[2], out var s)
+            ? throw new FormatException($"Invalid GTFS time format: '{time}'")
+            : (h * 3600) + (m * 60) + s;
+    }
+}

--- a/PublicTransportService/Infrastructure/PathFinding/Raptor/RaptorDataCacheRefresher.cs
+++ b/PublicTransportService/Infrastructure/PathFinding/Raptor/RaptorDataCacheRefresher.cs
@@ -30,8 +30,7 @@ internal class RaptorDataCacheRefresher(
                 var dbContext = scope.ServiceProvider.GetRequiredService<PTSDbContext>();
                 var currentTimestamp = await dbContext.GtfsMetadata
                     .Select(m => m.LastUpdated)
-                    .OrderBy((_) => _) // avoids warning
-                    .FirstAsync(stoppingToken);
+                    .SingleOrDefaultAsync(stoppingToken);
 
                 if (currentTimestamp != this.lastUpdateTimestamp)
                 {

--- a/PublicTransportService/PublicTransportService.csproj
+++ b/PublicTransportService/PublicTransportService.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="EFCore.BulkExtensions" Version="8.1.3" />
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.14">
       <PrivateAssets>all</PrivateAssets>
@@ -27,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Zrefaktoryzowano import danych GTFS, aby obsługiwał zarówno wstawianie danych za pomocą **EF Core**, jak i szybki **Bulk insert**.
Tryb Bulk znacząco przyspiesza import — nawet **10-krotnie** w porównaniu do EF Core.

---

## Wymagania dla Bulk insert

Aby skorzystać z trybu **Bulk insert**, należy:

* w pliku `appsettings.json` dodać do `ConnectionStrings.AppDbConnectionString` opcję:
  `AllowLoadLocalInfile=true`
* upewnić się, że serwer MySQL ma ustawione:
  `local-infile=1`

Jeśli w pliku zostanie włączona opcja `AllowLoadLocalInfile`, ale serwer nie będzie miał ustawionej opcji `local-infile`, import zakończy się niepowodzeniem.

Domyślnie (zgodnie z `appsettings.example.json`) używany jest tryb **EF Core**.

---

## Uruchamianie importera

Aby ręcznie uruchomić import danych:

```bash
dotnet run --project ./Tools/GtfsImporter <chunk_size> <local_zip_file>
```

Gdzie:

* `<chunk_size>` — rozmiar pojedynczego chunka, zalecane:

  * **500 000–2 000 000** dla Bulk insert,
  * **10 000–50 000** dla EF Core
    Jeśli nie podano, domyślnie `10 000`.
    Większe wartości zużywają więcej ramu.

* `<local_zip_file>` — ścieżka do lokalnego archiwum `.zip` z danymi GTFS (opcjonalne).
  Jeśli nie podano, zostanie pobrana najnowsza wersja z internetu.